### PR TITLE
Update build.gradle (com.scottyab:rootbeer-lib version bump)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,7 +53,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
-    implementation 'com.scottyab:rootbeer-lib:0.0.9'
+    implementation 'com.scottyab:rootbeer-lib:0.1.1'
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"


### PR DESCRIPTION
bumped version for com.scottyab:rootbeer-lib from 0.0.9 to 0.1.1 to support 16KB page sizes as described here: https://developer.android.com/guide/practices/page-sizes